### PR TITLE
Syscalls: Remove "m" input operands from inline assembly

### DIFF
--- a/user/include/l4/ia32/syscalls.h
+++ b/user/include/l4/ia32/syscalls.h
@@ -47,6 +47,13 @@
 # define __L4_CLOBBER_REGS	"ebx", "cc"
 #endif
 
+/*
+ * This expects the '__L4_indirect' struct in 'edi'
+ */
+#define __L4_INDIRECT_CALL	"	movl 4(%%edi), %%ebx	\n" \
+                                "	movl  (%%edi), %%edi	\n" \
+                                "	call *%%ebx		\n"
+
 #ifdef __cplusplus
 #define _C_ "C"
 #else
@@ -69,6 +76,13 @@ extern _C_ void __L4_Unmap(void);
 extern _C_ void __L4_SpaceControl(void);
 extern _C_ void __L4_ProcessorControl(void);
 extern _C_ void __L4_MemoryControl(void);
+
+typedef struct __L4_indirect
+{
+    L4_Word_t   edi;
+    void      (*sys_call)();
+} __L4_indirect;
+
 
 L4_INLINE void * L4_KernelInterface (L4_Word_t *ApiVersion,
 				     L4_Word_t *ApiFlags,
@@ -132,12 +146,12 @@ L4_INLINE L4_ThreadId_t L4_ExchangeRegisters (L4_ThreadId_t dest,
 	"       movl    8(%%esi), %%ebx                 \n"
 	"       movl    12(%%esi), %%esi                \n"
 	"       call    *(%%esp)                        \n"
-        "       xchgl   %%esi, 4(%%esp)                 \n"
-        "       movl    %%edi, 4(%%esi)                 \n"
-        "       movl    %%ebx, 8(%%esi)                 \n"
-        "       movl    %%ebp, (%%esi)                  \n"
-        "       popl    %%edi                           \n"
-        "       popl    %%esi                           \n"
+	"       xchgl   %%esi, 4(%%esp)                 \n"
+	"       movl    %%edi, 4(%%esi)                 \n"
+	"       movl    %%ebx, 8(%%esi)                 \n"
+	"       movl    %%ebp, (%%esi)                  \n"
+	"       popl    %%edi                           \n"
+	"       popl    %%esi                           \n"
 	__L4_RESTORE_REGS
         :
 	"=a" (result), "=c" (*old_control), "=d" (*old_sp), "=S" (*old_ip)
@@ -163,12 +177,14 @@ L4_INLINE L4_Word_t L4_ThreadControl (L4_ThreadId_t dest,
     L4_Word_t result;
     L4_Word_t dummy;
 
+    __L4_indirect in;
+    in.edi      = (L4_Word_t)UtcbLocation;
+    in.sys_call = __L4_ThreadControl;
+
     __asm__ __volatile__ (
 	"/* L4_ThreadControl() */			\n"
 	__L4_SAVE_REGS
-	"	movl	%%edi, %%ebx			\n"
-	"	movl	%9, %%edi			\n"
-	"	call	*%%ebx				\n"
+	__L4_INDIRECT_CALL
 	__L4_RESTORE_REGS
 
 	: /* outputs */
@@ -183,11 +199,10 @@ L4_INLINE L4_Word_t L4_ThreadControl (L4_ThreadId_t dest,
 	"1" (Pager),
 	"2" (Scheduler),
 	"3" (SpaceSpecifier),
-	"m" (UtcbLocation),
-	"D" (__L4_ThreadControl)
+	"4" (&in)
 
 	: /* clobbers */
-	__L4_CLOBBER_REGS);
+	__L4_CLOBBER_REGS, "memory");
 
     return result;
 }
@@ -239,12 +254,14 @@ L4_INLINE L4_Word_t  L4_Schedule (L4_ThreadId_t dest,
     L4_Word_t result;
     L4_Word_t dummy;
 
+    __L4_indirect in;
+    in.edi      = PreemptionControl;
+    in.sys_call = __L4_Schedule;
+
     __asm__ __volatile__ (
 	"/* L4_Schedule() */				\n"
 	__L4_SAVE_REGS
-	"	movl	%%edi, %%ebx			\n"
-	"	movl	%9, %%edi			\n"
-	"	call	*%%ebx				\n"
+	__L4_INDIRECT_CALL
 	__L4_RESTORE_REGS
 
 	: /* outputs */
@@ -259,11 +276,11 @@ L4_INLINE L4_Word_t  L4_Schedule (L4_ThreadId_t dest,
 	"1" (PrioControl),
 	"2" (TimeControl),
 	"3" (ProcessorControl),
-	"m" (PreemptionControl),
-	"D" (__L4_Schedule)
+	"4" (&in)
 
 	: /* clobbers */
-	__L4_CLOBBER_REGS);
+	__L4_CLOBBER_REGS, "memory");
+
     return result;
 }
 
@@ -278,14 +295,15 @@ L4_INLINE L4_MsgTag_t L4_Ipc (L4_ThreadId_t to,
     L4_Word_t * utcb = __L4_X86_Utcb ();
 
 #if defined(__pic__)
+    __L4_indirect in;
+    in.edi      = (L4_Word_t)utcb;
+    in.sys_call = __L4_Ipc;
 
     __asm__ __volatile__ (
 	"/* L4_Ipc() */					\n"
 	__L4_SAVE_REGS
-	"	movl	%%eax, %%ebx			\n"
-	"	movl	%5, %%eax			\n"
-	"	call	*%%ebx				\n"
-        "	movl	%%ebp, %%ecx			\n"
+	__L4_INDIRECT_CALL
+	"	movl	%%ebp, %%ecx			\n"
 	"	movl	%%ebx, %%edx			\n"
 	__L4_RESTORE_REGS
 
@@ -297,12 +315,12 @@ L4_INLINE L4_MsgTag_t L4_Ipc (L4_ThreadId_t to,
         
 	: /* inputs */
 	"S" (utcb[0]),
-	"m" (to.raw),
-	"D" (utcb),
+	"a" (to.raw),
+	"D" (&in),
 	"c" (Timeouts),
-	"d" (FromSpecifier),
-	"a" (__L4_Ipc)
-	);
+	"d" (FromSpecifier)
+
+	: "memory");
 
 #else
     L4_Word_t dummy;
@@ -319,7 +337,7 @@ L4_INLINE L4_MsgTag_t L4_Ipc (L4_ThreadId_t to,
 	"=a" (result),
 	"=b" (mr1),
 	"=c" (mr2),
-    "=d" (dummy)
+	"=d" (dummy)
         
 	: /* inputs */
 	"S" (utcb[0]),
@@ -351,12 +369,15 @@ L4_INLINE L4_MsgTag_t L4_Lipc (L4_ThreadId_t to,
     L4_Word_t * utcb = __L4_X86_Utcb ();
 
 #if defined(__pic__)
+
+    __L4_indirect in;
+    in.edi      = (L4_Word_t)utcb;
+    in.sys_call = __L4_Lipc;
+
     __asm__ __volatile__ (
 	"/* L4_Lipc() */				\n"
 	__L4_SAVE_REGS
-	"	movl	%%eax, %%ebx			\n"
-	"	movl	%5, %%eax			\n"
-	"	call	*%%ebx				\n"
+	__L4_INDIRECT_CALL
 	"	movl	%%ebp, %%ecx			\n"
 	"	movl	%%ebx, %%edx			\n"
 	__L4_RESTORE_REGS
@@ -366,15 +387,15 @@ L4_INLINE L4_MsgTag_t L4_Lipc (L4_ThreadId_t to,
 	"=a" (result),
 	"=d" (mr1),
 	"=c" (mr2)
-        
+
 	: /* inputs */
 	"S" (utcb[0]),
-	"m" (to.raw),
-	"D" (utcb),
+	"a" (to.raw),
+	"D" (&in),
 	"c" (Timeouts),
-	"d" (FromSpecifier),
-	"a" (__L4_Lipc)
-	);
+	"d" (FromSpecifier)
+
+	: "memory");
 #else
     L4_Word_t dummy;
 
@@ -382,7 +403,7 @@ L4_INLINE L4_MsgTag_t L4_Lipc (L4_ThreadId_t to,
 	"/* L4_Lipc() */				\n"
 	__L4_SAVE_REGS
 	"	call	__L4_Lipc			\n"
-        "	movl	%%ebp, %%ecx			\n"
+	"	movl	%%ebp, %%ecx			\n"
 	__L4_RESTORE_REGS
 
 	: /* outputs */
@@ -390,8 +411,8 @@ L4_INLINE L4_MsgTag_t L4_Lipc (L4_ThreadId_t to,
 	"=a" (result),
 	"=b" (mr1),
 	"=c" (mr2),
-        "=d" (dummy)
-        
+	"=d" (dummy)
+
 	: /* inputs */
 	"S" (utcb[0]),
 	"a" (to.raw),
@@ -446,12 +467,14 @@ L4_INLINE L4_Word_t L4_SpaceControl (L4_ThreadId_t SpaceSpecifier,
 {
     L4_Word_t result, dummy;
 
+    __L4_indirect in;
+    in.edi      = redirector.raw;
+    in.sys_call = __L4_SpaceControl;
+
     __asm__ __volatile__ (
 	"/* L4_SpaceControl() */			\n"
 	__L4_SAVE_REGS
-	"	movl	%%edi, %%ebx			\n"
-	"	movl	%9, %%edi			\n"
-	"	call	*%%ebx				\n"
+	__L4_INDIRECT_CALL
 	__L4_RESTORE_REGS
 
 	: /* outputs */
@@ -466,11 +489,10 @@ L4_INLINE L4_Word_t L4_SpaceControl (L4_ThreadId_t SpaceSpecifier,
 	"1" (control),
 	"2" (KernelInterfacePageArea),
 	"3" (UtcbArea),
-	"m" (redirector),
-	"D" (__L4_SpaceControl)
+	"4" (&in)
 
 	: /* clobbers */
-	__L4_CLOBBER_REGS);
+	__L4_CLOBBER_REGS, "memory");
 
     return result;
 }
@@ -516,22 +538,23 @@ L4_INLINE L4_Word_t L4_MemoryControl (L4_Word_t control,
     L4_Word_t result, dummy;
     L4_Word_t * utcb = __L4_X86_Utcb ();
 
+    __L4_indirect in;
+    in.edi      = (L4_Word_t)utcb;
+    in.sys_call = __L4_MemoryControl;
+
     __asm__ __volatile__ (
 	"/* L4_MemoryControl() */			\n"
 	__L4_SAVE_REGS
-	"	pushl	%%edi				\n"
-	"	movl	%8, %%edi			\n"
 	"	movl	12(%6), %%ebp			\n"
 	"	movl	8(%6), %%ebx			\n"
 	"	movl	4(%6), %%edx			\n"
 	"	movl	(%6), %%ecx			\n"
-	"	call	*(%%esp)			\n"
-	"	popl	%%edi				\n"
+	__L4_INDIRECT_CALL
 	__L4_RESTORE_REGS
 
 	: /* outputs */
 	"=a" (result),
- 	"=c" (dummy),
+	"=c" (dummy),
 	"=d" (dummy),
 	"=S" (dummy),
 	"=D" (dummy)
@@ -540,11 +563,10 @@ L4_INLINE L4_Word_t L4_MemoryControl (L4_Word_t control,
 	"0" (control),
 	"1" (attributes),
 	"3" (utcb[0]),
-	"m" (utcb),
-	"4" (__L4_MemoryControl)
+	"4" (&in)
 
 	: /* clobbers */
-	__L4_CLOBBER_REGS);
+	__L4_CLOBBER_REGS, "memory");
 
     return result;
 }


### PR DESCRIPTION
GCC-4.6 seems to use stack relative addressing for memory input operands (as
opposed to base-pointer relative in older GCC versions). Since most system calls
will change the stack behind the compilers back do not use memory inputs any
more.

This is just a suggestion how to solve this problem.

Greetings,

Sebastian
